### PR TITLE
Fix mod path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module govanish
+module github.com/sivukhin/govanish
 
 go 1.21.0
 


### PR DESCRIPTION
Hi 👋🏻 

Saw you linter was used in https://github.com/golang/go/issues/64961 and wanted to test it, but was unable to install it:

```
➜  ~ go install github.com/sivukhin/govanish@latest

go: downloading github.com/sivukhin/govanish v0.0.0-20240113103648-a4d8a6fc86af
go: github.com/sivukhin/govanish@latest: version constraints conflict:
	github.com/sivukhin/govanish@v0.0.0-20240113103648-a4d8a6fc86af: parsing go.mod:
	module declares its path as: govanish
	        but was required as: github.com/sivukhin/govanish
```

I think this is due to an error in `go.mod`