### PR TITLE
Add install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-## govanish
+# govanish
+
+## Installation
+
+```bash
+go install github.com/sivukhin/govanish@latest
+```
+
+## Purpose
 
 It might not be a surprise to you that your code can simply disappear from the compiled binary for multiple reasons.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # govanish
 
-## Installation
+`govanish` will highlight lines of code which most likely were removed by the compiler from the final executable binary.
+
+## Usage
 
 ```bash
-go install github.com/sivukhin/govanish@latest
+$> go install github.com/sivukhin/govanish@latest
+$> cd /path/to/your/module && govanish # go to your module and run govanish from root directory with go.mod file
+$> govanish /path/to/your/module       # or you can provide path to the root directory as first argument
 ```
 
 ## Purpose

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ func main() {
 		if err != nil {
 			panic(fmt.Errorf("unable to get working directory: %w", err))
 		}
+	} else {
+		panic(fmt.Errorf("usage: govanish | govanish [module path]"))
 	}
 	log.Printf("module path: %v", analysisPath)
 	assemblyLines, err := AnalyzeModuleAssembly(analysisPath)


### PR DESCRIPTION
Make it a bit more beginner friendly 

I think it's a normal pattern for linters to specify the installation at the top of readme:
- https://github.com/alexkohler/prealloc
- https://github.com/mdempsky/unconvert
- https://github.com/mgechev/revive